### PR TITLE
Added feature to use a visibility mask image for rendering.

### DIFF
--- a/src/main/java/Interactive_3D_Surface_Plot.java
+++ b/src/main/java/Interactive_3D_Surface_Plot.java
@@ -1418,6 +1418,14 @@ public class Interactive_3D_Surface_Plot implements PlugIn, MouseListener, Mouse
 				loadTextureImage();
 			}
 		});
+
+		// create mask image button
+		JButton maskImageButton = new JButton("Load Mask");
+		maskImageButton.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+			    loadMaskImage();
+			}
+		});
 		
 		final JPopupMenu popup = new JPopupMenu();
 		
@@ -1521,13 +1529,14 @@ public class Interactive_3D_Surface_Plot implements PlugIn, MouseListener, Mouse
 		
 		// create combo panel
 		JPanel panel = new JPanel();
-		panel.setLayout(new GridLayout(1, 5, 0, 0));		
+		panel.setLayout(new GridLayout(1, 6, 0, 0));
 		
 		
 	    // add elements to combo panel
 		panel.add(comboDisplayType);		
 		panel.add(comboDisplayColors);
 		panel.add(textureButton);
+		panel.add(maskImageButton);
 		panel.add(saveButton);
 		panel.add(optionsButton);
 		
@@ -1615,6 +1624,83 @@ public class Interactive_3D_Surface_Plot implements PlugIn, MouseListener, Mouse
 		}
 	}
 
+	private void loadMaskImage() {
+		ImagePlus impMask = null;
+
+		int[] wList = WindowManager.getIDList();
+		boolean loadFromDisk = false;
+		if (wList==null) {
+			loadFromDisk = true;
+		}
+		else {
+			String[] titles = new String[wList.length + 1];
+			for (int i=0; i<wList.length; i++) {
+				ImagePlus imp = WindowManager.getImage(wList[i]);
+				if (imp!=null)
+					titles[i] = imp.getTitle();
+				else
+					titles[i] = "";
+			}
+			titles[wList.length] = "\"Load File from Disk\"";
+
+			GenericDialog gd = new GenericDialog("Load mask image", IJ.getInstance());
+
+			gd.addMessage("Please select an image to be used as a mask image.");
+
+			String defaultItem = titles[0];
+			gd.addChoice("Open Image:", titles, defaultItem);
+
+			gd.showDialog();
+			if (gd.wasCanceled())
+				return;
+			int index = gd.getNextChoiceIndex();
+			if(titles[index].equals("\"Load File from Disk\""))
+				loadFromDisk = true;
+			else {
+				impMask = WindowManager.getImage(wList[index]);
+			}
+		}
+
+		if (loadFromDisk == true) {
+			JFileChooser fc = new JFileChooser();		// open mask image
+
+			if (fc.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
+				String str = fc.getSelectedFile().getPath();
+				try {
+					IJ.run("Open...", "path='"+str+"'");
+					impMask = WindowManager.getCurrentImage();
+				} catch (RuntimeException e) {
+					JOptionPane.showMessageDialog(null,"Error opening Image","",JOptionPane.PLAIN_MESSAGE);
+					return;
+				}
+			}
+		}
+
+		if (impMask != null) {
+			jRenderer3D.setSurfacePlotMask(impMask);
+
+			setSurfacePlotType(plotType);
+
+			jRenderer3D.setSurfacePlotLight(light);
+
+			minSlider = sliderMin.getValue();
+			maxSlider = sliderMax.getValue();
+
+			jRenderer3D.setSurfacePlotMinMax(minSlider, maxSlider);
+			jRenderer3D.surfacePlotSetInverse(invertZ);
+
+			grid = 1 << sliderGridSize.getValue();
+			smooth = sliderSmoothing.getValue() * (grid / 512.);
+			if (smooth < 1) smooth = 0;
+			jRenderer3D.setSurfaceSmoothingFactor(smooth);
+			smoothOld = smooth;
+
+			setSurfaceColorType(colorType);
+			comboDisplayColors.setSelectedIndex(colorType);
+
+			renderAndUpdateDisplay();
+		}
+	}
 
 	private JPanel createSliderPanel1() {				
 		// create sliders 

--- a/src/main/java/jRenderer3D/JRenderer3D.java
+++ b/src/main/java/jRenderer3D/JRenderer3D.java
@@ -254,6 +254,7 @@ public class JRenderer3D {
 	private int 		surfacePlot_gridHeight= SURFACEGRID_DEFAULTHEIGHT;
 	private ImagePlus 	surfacePlot_imagePlusData = null;   // image used for the surface plot 
 	private ImagePlus 	surfacePlot_imagePlusTexture = null; // texture image
+	private ImagePlus 	surfacePlot_imagePlusMask = null; // mask image
 	private int 		surfacePlot_plotMode = SURFACEPLOT_LINES;
 	private int 		surfacePlot_lutNr = LUT_ORIGINAL;
 	private double		surfacePlot_light = 0;
@@ -1040,6 +1041,14 @@ public class JRenderer3D {
 		surfacePlot_imagePlusTexture = impTexture;
 		if (surfacePlot != null) {
 			surfacePlot.setSurfacePlotTextureImage(impTexture);
+			surfacePlot.resample();
+		}
+	}
+
+	public void setSurfacePlotMask(ImagePlus impMask) {
+		surfacePlot_imagePlusMask = impMask;
+		if (surfacePlot != null) {
+			surfacePlot.setSurfacePlotMaskImage(impMask);
 			surfacePlot.resample();
 		}
 	}

--- a/src/main/java/jRenderer3D/SurfacePlot.java
+++ b/src/main/java/jRenderer3D/SurfacePlot.java
@@ -55,6 +55,9 @@ class SurfacePlot {
 	private int widthTex;
 	private int heightTex;
 	private int[] pixelsTexColor;
+	private int widthMaskImage;
+	private int heightMaskImage;
+	private byte[] pixelsMaskImage;
 	private byte[] maskPixels;
 	
 	
@@ -74,7 +77,6 @@ class SurfacePlot {
 	}
 	
 	protected void setSurfacePlotImage(ImagePlus imp){
-	
 			int widthTmp = imp.getWidth();
 			int heightTmp = imp.getHeight();
 	
@@ -251,8 +253,12 @@ class SurfacePlot {
 			pixelsTexColor =  null;
 		}
 	}
-	
 
+	protected void setSurfacePlotMaskImage(ImagePlus imp){
+		widthMaskImage = imp.getWidth();
+		heightMaskImage = imp.getHeight();
+		pixelsMaskImage = (byte []) imp.getProcessor().getPixels();
+	}
 
 	protected void resample(){
 		
@@ -309,6 +315,24 @@ class SurfacePlot {
 					int xB = (int) (x * sx);
 					
 					plotList[pos].color = pixelsTexColor[yB * widthTex + xB];
+				}
+			}
+		}
+
+		if (pixelsMaskImage != null) {
+
+			double sx = widthMaskImage / (double) gridWidth;
+			double sy = heightMaskImage / (double) gridHeight;
+
+			for (int y = 0; y < gridHeight; y++) {
+				int yB = (int) (y * sy);
+
+				for (int x = 0; x < gridWidth; x++) {
+					int pos = y * gridWidth + x;
+
+					int xB = (int) (x * sx);
+
+					plotList[pos].isVisible = pixelsMaskImage[yB * widthMaskImage + xB] == 0 ? false : true;
 				}
 			}
 		}


### PR DESCRIPTION
I added a button to optionally load an image, that can be used as a mask for controlling pixel level visibilty of the rendered image. Only pixels corresponding to non-zeroes in the optionally loaded mask image, are visible in the rendering. 
A "Load Mask" button was added to the UI by copying and modifying the "Load Texture" button code.
